### PR TITLE
Changed references to allow building and running with PCL libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# Visual Studio 2015 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
 # Roslyn cache directories
 *.ide/
 

--- a/WikipediaProcessing/WikimediaProcessing/WikiSection.cs
+++ b/WikipediaProcessing/WikimediaProcessing/WikiSection.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace WikimediaProcessing
 {

--- a/WikipediaProcessing/WikimediaProcessing/Wikimedia.cs
+++ b/WikipediaProcessing/WikimediaProcessing/Wikimedia.cs
@@ -1,19 +1,17 @@
 ﻿using ICSharpCode.SharpZipLib.BZip2;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 using System.Xml;
 
 namespace WikimediaProcessing
 {
     public class Wikimedia
     {
-        private Stream input;
-        private XmlReader xmlReader;
+        private readonly Stream input;
+        private readonly XmlReader xmlReader;
         private readonly XmlReaderSettings settings = new XmlReaderSettings()
         {
             ValidationType = ValidationType.None,
@@ -64,12 +62,11 @@ namespace WikimediaProcessing
                 {
                     using (var bh = new BinaryReader(input, Encoding.UTF8))
                     {
-                        var jss = new JavaScriptSerializer();
                         while (input.Position != input.Length)
                         {
                             var json = bh.ReadString();
 
-                            var article = jss.Deserialize<WikimediaPage>(json);
+                            var article = JsonConvert.DeserializeObject<WikimediaPage>(json);
 
                             yield return article;
                         }
@@ -111,10 +108,9 @@ namespace WikimediaProcessing
             using (var fh = File.Create(outputFilename))
             using (var bh = new BinaryWriter(fh))
             {
-                var jss = new JavaScriptSerializer();
                 foreach (var article in articles)
                 {
-                    var json = jss.Serialize(article);
+                    var json = JsonConvert.SerializeObject(article);
 
                     bh.Write(json);
                     ++numberOfArticles;

--- a/WikipediaProcessing/WikimediaProcessing/WikimediaMarkup.cs
+++ b/WikipediaProcessing/WikimediaProcessing/WikimediaMarkup.cs
@@ -18,7 +18,6 @@
         /// </summary>
         public static readonly Regex SpecialPageRegex;
         private static readonly Regex RemoveParensRegex;
-        private static readonly Regex LinkTemplateRegex;
         private static readonly IList<Tuple<Regex, string>> OrderedRegexes;
         static WikimediaMarkup()
         {

--- a/WikipediaProcessing/WikimediaProcessing/WikimediaPage.cs
+++ b/WikipediaProcessing/WikimediaProcessing/WikimediaPage.cs
@@ -1,12 +1,6 @@
-﻿using ICSharpCode.SharpZipLib.BZip2;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.IO.Compression;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Web.Script.Serialization;
-using System.Xml;
 
 namespace WikimediaProcessing
 {

--- a/WikipediaProcessing/WikimediaProcessing/WikimediaProcessing.csproj
+++ b/WikipediaProcessing/WikimediaProcessing/WikimediaProcessing.csproj
@@ -30,13 +30,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ICSharpCode.SharpZipLib.Portable, Version=0.86.0.51803, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.Portable.0.86.0.0003\lib\portable-net45+netcore45+wp8+win8+wpa81+MonoTouch+MonoAndroid+Xamarin.iOS10\ICSharpCode.SharpZipLib.Portable.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/WikipediaProcessing/WikimediaProcessing/packages.config
+++ b/WikipediaProcessing/WikimediaProcessing/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net45" />
+  <package id="SharpZipLib.Portable" version="0.86.0.0003" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi. 

I've changed SharpZipLib to SharpZipLib.Portable and removed System.Web.Extensions in favor of Newtonsoft.Json to allow linking WikimediaProcessing to .NET Core/Standard projects. The example projects run OK. 

The library itself is great, thank you!