### PR TITLE
extracting Article id

### DIFF
--- a/WikipediaProcessing/WikimediaProcessing/Wikimedia.cs
+++ b/WikipediaProcessing/WikimediaProcessing/Wikimedia.cs
@@ -85,12 +85,16 @@ namespace WikimediaProcessing
             x.ReadToFollowing("title");
             var title = x.ReadString();
 
+            x.ReadToFollowing("id");
+            var id = x.ReadElementContentAsInt();
+
             x.ReadToFollowing("text");
             var text = x.ReadElementContentAsString();
 
             return new WikimediaPage
             {
                 Title = title,
+                Id = id,
                 Text = text
             };
         }

--- a/WikipediaProcessing/WikimediaProcessing/WikimediaPage.cs
+++ b/WikipediaProcessing/WikimediaProcessing/WikimediaPage.cs
@@ -7,6 +7,11 @@ namespace WikimediaProcessing
     public class WikimediaPage
     {
         /// <summary>
+        /// The Wikipedia article id
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
         /// The Wikipedia article title
         /// </summary>
         public string Title;


### PR DESCRIPTION
As discussed in #2 here is my PR.
I run through enwiki-20191201-pages-articles-multistream.xml completely.

using `int` instead of `long` should not be a issue as the biggest current id is ~62M

